### PR TITLE
Add unit tests for token services

### DIFF
--- a/src/test/java/com/mercadotech/authserver/adapter/JwtTokenServiceTest.java
+++ b/src/test/java/com/mercadotech/authserver/adapter/JwtTokenServiceTest.java
@@ -1,0 +1,25 @@
+package com.mercadotech.authserver.adapter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JwtTokenServiceTest {
+
+    private final JwtTokenService service = new JwtTokenService();
+    private final String clientId = "client";
+    private final String secret = "secretsecretsecretsecretsecretsecret"; // 32+ characters for HS256
+
+    @Test
+    void generateTokenReturnsValidJwt() {
+        String token = service.generateToken(clientId, secret);
+        assertThat(token).isNotNull();
+        assertThat(service.validateToken(token, secret)).isTrue();
+    }
+
+    @Test
+    void validateTokenFailsWithWrongSecret() {
+        String token = service.generateToken(clientId, secret);
+        assertThat(service.validateToken(token, secret + "x")).isFalse();
+    }
+}

--- a/src/test/java/com/mercadotech/authserver/application/useCase/TokenUseCaseImplTest.java
+++ b/src/test/java/com/mercadotech/authserver/application/useCase/TokenUseCaseImplTest.java
@@ -1,0 +1,37 @@
+package com.mercadotech.authserver.application.useCase;
+
+import com.mercadotech.authserver.domain.TokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class TokenUseCaseImplTest {
+
+    private TokenService tokenService;
+    private TokenUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        tokenService = Mockito.mock(TokenService.class);
+        useCase = new TokenUseCaseImpl(tokenService);
+    }
+
+    @Test
+    void generateTokenDelegatesToService() {
+        when(tokenService.generateToken("id", "secret")).thenReturn("token");
+        String result = useCase.generateToken("id", "secret");
+        assertThat(result).isEqualTo("token");
+        verify(tokenService).generateToken("id", "secret");
+    }
+
+    @Test
+    void validateTokenDelegatesToService() {
+        when(tokenService.validateToken("tok", "sec")).thenReturn(true);
+        boolean result = useCase.validateToken("tok", "sec");
+        assertThat(result).isTrue();
+        verify(tokenService).validateToken("tok", "sec");
+    }
+}


### PR DESCRIPTION
## Summary
- add the test source tree following Spring Boot conventions
- add unit tests for `JwtTokenService`
- add unit tests for `TokenUseCaseImpl`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685418fa92e88324bab21af6ce0a4a4b