### PR TITLE
Create service folder and refactor use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ This project demonstrates a simple hexagonal architecture. A use case service is
 provided to create and validate JWT Bearer tokens using a client identifier and
 client secret. The domain exposes a `TokenService` port, implemented by
 `JwtTokenService` in the adapter layer. The application layer exposes
-`TokenUseCase` for interacting with the domain. Lombok annotations
+`TokenUseCase` for interacting with the domain. Its implementation,
+`TokenUseCaseImpl`, now lives in the `application.service` package. Lombok annotations
 are used to reduce boilerplate in service implementations.

--- a/src/main/java/com/mercadotech/authserver/application/service/TokenUseCaseImpl.java
+++ b/src/main/java/com/mercadotech/authserver/application/service/TokenUseCaseImpl.java
@@ -1,5 +1,6 @@
-package com.mercadotech.authserver.application.useCase;
+package com.mercadotech.authserver.application.service;
 
+import com.mercadotech.authserver.application.useCase.TokenUseCase;
 import com.mercadotech.authserver.domain.TokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/test/java/com/mercadotech/authserver/application/service/TokenUseCaseImplTest.java
+++ b/src/test/java/com/mercadotech/authserver/application/service/TokenUseCaseImplTest.java
@@ -1,6 +1,8 @@
-package com.mercadotech.authserver.application.useCase;
+package com.mercadotech.authserver.application.service;
 
+import com.mercadotech.authserver.application.useCase.TokenUseCase;
 import com.mercadotech.authserver.domain.TokenService;
+import com.mercadotech.authserver.application.service.TokenUseCaseImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;


### PR DESCRIPTION
## Summary
- move `TokenUseCaseImpl` to a new `application.service` package
- update tests and README to reflect new package structure

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685419f578d88324a05618836ef07537