### PR TITLE
Add client credential login and validation endpoints

### DIFF
--- a/src/main/java/com/mercadotech/authserver/adapter/AuthController.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/AuthController.java
@@ -1,0 +1,33 @@
+package com.mercadotech.authserver.adapter;
+
+import com.mercadotech.authserver.adapter.dto.LoginRequest;
+import com.mercadotech.authserver.adapter.dto.TokenResponse;
+import com.mercadotech.authserver.adapter.dto.ValidateRequest;
+import com.mercadotech.authserver.adapter.dto.ValidateResponse;
+import com.mercadotech.authserver.application.useCase.TokenUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final TokenUseCase tokenUseCase;
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request) {
+        String token = tokenUseCase.generateToken(request.getClientId(), request.getClientSecret());
+        return ResponseEntity.ok(new TokenResponse(token));
+    }
+
+    @PostMapping("/token/validate")
+    public ResponseEntity<ValidateResponse> validate(@RequestBody ValidateRequest request) {
+        boolean valid = tokenUseCase.validateToken(request.getToken(), request.getClientSecret());
+        return ResponseEntity.ok(new ValidateResponse(valid));
+    }
+}

--- a/src/main/java/com/mercadotech/authserver/adapter/dto/LoginRequest.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.mercadotech.authserver.adapter.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+    private String clientId;
+    private String clientSecret;
+}

--- a/src/main/java/com/mercadotech/authserver/adapter/dto/TokenResponse.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/dto/TokenResponse.java
@@ -1,0 +1,10 @@
+package com.mercadotech.authserver.adapter.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TokenResponse {
+    private String token;
+}

--- a/src/main/java/com/mercadotech/authserver/adapter/dto/ValidateRequest.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/dto/ValidateRequest.java
@@ -1,0 +1,9 @@
+package com.mercadotech.authserver.adapter.dto;
+
+import lombok.Data;
+
+@Data
+public class ValidateRequest {
+    private String token;
+    private String clientSecret;
+}

--- a/src/main/java/com/mercadotech/authserver/adapter/dto/ValidateResponse.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/dto/ValidateResponse.java
@@ -1,0 +1,10 @@
+package com.mercadotech.authserver.adapter.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ValidateResponse {
+    private boolean valid;
+}

--- a/src/test/java/com/mercadotech/authserver/adapter/AuthControllerTest.java
+++ b/src/test/java/com/mercadotech/authserver/adapter/AuthControllerTest.java
@@ -1,0 +1,57 @@
+package com.mercadotech.authserver.adapter;
+
+import com.mercadotech.authserver.adapter.dto.LoginRequest;
+import com.mercadotech.authserver.adapter.dto.TokenResponse;
+import com.mercadotech.authserver.adapter.dto.ValidateRequest;
+import com.mercadotech.authserver.adapter.dto.ValidateResponse;
+import com.mercadotech.authserver.application.useCase.TokenUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class AuthControllerTest {
+
+    private TokenUseCase useCase;
+    private AuthController controller;
+
+    @BeforeEach
+    void setUp() {
+        useCase = Mockito.mock(TokenUseCase.class);
+        controller = new AuthController(useCase);
+    }
+
+    @Test
+    void loginReturnsTokenFromUseCase() {
+        LoginRequest request = new LoginRequest();
+        request.setClientId("id");
+        request.setClientSecret("sec");
+        when(useCase.generateToken("id", "sec")).thenReturn("tok");
+
+        ResponseEntity<TokenResponse> response = controller.login(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getToken()).isEqualTo("tok");
+        verify(useCase).generateToken("id", "sec");
+    }
+
+    @Test
+    void validateReturnsResultFromUseCase() {
+        ValidateRequest request = new ValidateRequest();
+        request.setToken("tok");
+        request.setClientSecret("sec");
+        when(useCase.validateToken("tok", "sec")).thenReturn(true);
+
+        ResponseEntity<ValidateResponse> response = controller.validate(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().isValid()).isTrue();
+        verify(useCase).validateToken("tok", "sec");
+    }
+}


### PR DESCRIPTION
## Summary
- expose `/login` endpoint to obtain a token
- add `/token/validate` endpoint to validate existing tokens
- provide request/response DTOs for these endpoints
- add unit tests for `AuthController`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541bd203248324ac52a1e5630fdc87