### PR TITLE
Add Prometheus metrics and log configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,18 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
             <version>0.11.5</version>

--- a/src/main/java/com/mercadotech/authserver/adapter/AuthController.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/AuthController.java
@@ -10,8 +10,13 @@ import com.mercadotech.authserver.adapter.mapper.TokenResponseMapper;
 import com.mercadotech.authserver.application.useCase.TokenUseCase;
 import com.mercadotech.authserver.domain.model.Credentials;
 import com.mercadotech.authserver.domain.model.TokenData;
-import lombok.RequiredArgsConstructor;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,17 +24,39 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping
-@RequiredArgsConstructor
 public class AuthController {
 
+    private static final Logger logger = LoggerFactory.getLogger(AuthController.class);
+
     private final TokenUseCase tokenUseCase;
+    private final Counter tokensIssuedCounter;
+    private final Timer loginTimer;
+
+    public AuthController(TokenUseCase tokenUseCase, MeterRegistry registry) {
+        this.tokenUseCase = tokenUseCase;
+        this.tokensIssuedCounter = Counter.builder("auth_tokens_issued")
+                .description("Number of tokens issued")
+                .register(registry);
+        this.loginTimer = Timer.builder("auth_login_latency")
+                .description("Latency of login endpoint")
+                .register(registry);
+    }
 
     @PostMapping("/login")
     public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request) {
-        Credentials credentials = CredentialsMapper.from(request);
-        TokenData tokenData = tokenUseCase.generateToken(credentials);
-        TokenResponse response = TokenResponseMapper.from(tokenData);
-        return ResponseEntity.ok(response);
+        try {
+            return loginTimer.record(() -> {
+                Credentials credentials = CredentialsMapper.from(request);
+                TokenData tokenData = tokenUseCase.generateToken(credentials);
+                tokensIssuedCounter.increment();
+                logger.info("Login success for client {}", credentials.getClientId());
+                TokenResponse response = TokenResponseMapper.from(tokenData);
+                return ResponseEntity.ok(response);
+            });
+        } catch (Exception e) {
+            logger.error("Login failed for client {}", request.getClientId(), e);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
     }
 
     @PostMapping("/token/validate")
@@ -37,6 +64,11 @@ public class AuthController {
         Credentials credentials = CredentialsMapper.from(request);
         TokenData tokenData = TokenMapper.from(request);
         boolean valid = tokenUseCase.validateToken(tokenData, credentials);
+        if (valid) {
+            logger.info("Token validation success");
+        } else {
+            logger.warn("Token validation failed");
+        }
         return ResponseEntity.ok(ValidateResponse.builder().valid(valid).build());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+management.endpoints.web.exposure.include=prometheus
+LOG_PATTERN=%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="LOG_PATTERN" value="${LOG_PATTERN:-%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n}"/>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/src/test/java/com/mercadotech/authserver/adapter/AuthControllerTest.java
+++ b/src/test/java/com/mercadotech/authserver/adapter/AuthControllerTest.java
@@ -7,6 +7,7 @@ import com.mercadotech.authserver.adapter.dto.ValidateResponse;
 import com.mercadotech.authserver.domain.model.Credentials;
 import com.mercadotech.authserver.domain.model.TokenData;
 import com.mercadotech.authserver.application.useCase.TokenUseCase;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -20,11 +21,13 @@ class AuthControllerTest {
 
     private TokenUseCase useCase;
     private AuthController controller;
+    private SimpleMeterRegistry registry;
 
     @BeforeEach
     void setUp() {
         useCase = Mockito.mock(TokenUseCase.class);
-        controller = new AuthController(useCase);
+        registry = new SimpleMeterRegistry();
+        controller = new AuthController(useCase, registry);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- expose Prometheus metrics using Micrometer
- log authentication success and failure with slf4j/logback
- create parameterized `logback-spring.xml`
- expose `/actuator/prometheus` via application properties
- update tests for new controller constructor

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685423ac3a888324a9324b943e0358cc