### PR TITLE
Format logs as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,20 @@ client secret. The domain exposes a `TokenService` port, implemented by
 `TokenUseCase` for interacting with the domain. Its implementation,
 `TokenUseCaseImpl`, now lives in the `application.service` package. Lombok annotations
 are used to reduce boilerplate in service implementations.
+
+## Logging
+
+The application logs messages in JSON format to make aggregation easier. Each entry contains the timestamp, log level, class name, Kubernetes pod name and a correlation ID if available:
+
+```json
+{
+  "timestamp": "2025-06-19T14:00:00Z",
+  "level": "INFO",
+  "class": "class-name",
+  "pod_name": "order-service-abc123",
+  "message": "Order processed successfully",
+  "correlation_id": "uuid"
+}
+```
+
+The pod name is taken from the `POD_NAME` environment variable and the correlation ID comes from the MDC key `correlation_id`.

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <property name="LOG_PATTERN" value="${LOG_PATTERN:-%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n}"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>${LOG_PATTERN}</pattern>
+            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}","level":"%level","class":"%logger{36}","pod_name":"${POD_NAME:-}","message":"%msg","correlation_id":"%X{correlation_id}"}</pattern>
         </encoder>
     </appender>
     <root level="INFO">


### PR DESCRIPTION
## Summary
- output logs using a JSON pattern with pod and correlation ID
- document the log format in the README

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685425e60b3883248d025268bafeda31