### PR TITLE
Add mapper unit tests

### DIFF
--- a/src/test/java/com/mercadotech/authserver/adapter/AuthControllerTest.java
+++ b/src/test/java/com/mercadotech/authserver/adapter/AuthControllerTest.java
@@ -68,4 +68,21 @@ class AuthControllerTest {
         assertThat(response.getBody().isValid()).isTrue();
         verify(useCase).validateToken(tokenData, credentials);
     }
+
+    @Test
+    void loginReturnsUnauthorizedOnException() {
+        LoginRequest request = new LoginRequest();
+        request.setClientId("id");
+        request.setClientSecret("sec");
+        Credentials credentials = Credentials.builder()
+                .clientId("id")
+                .clientSecret("sec")
+                .build();
+        when(useCase.generateToken(credentials)).thenThrow(new RuntimeException("err"));
+
+        ResponseEntity<TokenResponse> response = controller.login(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        verify(useCase).generateToken(credentials);
+    }
 }

--- a/src/test/java/com/mercadotech/authserver/adapter/mapper/CredentialsMapperTest.java
+++ b/src/test/java/com/mercadotech/authserver/adapter/mapper/CredentialsMapperTest.java
@@ -1,0 +1,37 @@
+package com.mercadotech.authserver.adapter.mapper;
+
+import com.mercadotech.authserver.adapter.dto.LoginRequest;
+import com.mercadotech.authserver.adapter.dto.ValidateRequest;
+import com.mercadotech.authserver.domain.model.Credentials;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CredentialsMapperTest {
+
+    @Test
+    void fromLoginRequestMapsAllFields() {
+        LoginRequest request = LoginRequest.builder()
+                .clientId("id")
+                .clientSecret("sec")
+                .build();
+
+        Credentials result = CredentialsMapper.from(request);
+
+        assertThat(result.getClientId()).isEqualTo("id");
+        assertThat(result.getClientSecret()).isEqualTo("sec");
+    }
+
+    @Test
+    void fromValidateRequestMapsSecret() {
+        ValidateRequest request = ValidateRequest.builder()
+                .token("tok")
+                .clientSecret("sec")
+                .build();
+
+        Credentials result = CredentialsMapper.from(request);
+
+        assertThat(result.getClientId()).isNull();
+        assertThat(result.getClientSecret()).isEqualTo("sec");
+    }
+}

--- a/src/test/java/com/mercadotech/authserver/adapter/mapper/TokenMapperTest.java
+++ b/src/test/java/com/mercadotech/authserver/adapter/mapper/TokenMapperTest.java
@@ -1,0 +1,22 @@
+package com.mercadotech.authserver.adapter.mapper;
+
+import com.mercadotech.authserver.adapter.dto.ValidateRequest;
+import com.mercadotech.authserver.domain.model.TokenData;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenMapperTest {
+
+    @Test
+    void fromValidateRequestMapsToken() {
+        ValidateRequest request = ValidateRequest.builder()
+                .token("tok")
+                .clientSecret("secret")
+                .build();
+
+        TokenData result = TokenMapper.from(request);
+
+        assertThat(result.getToken()).isEqualTo("tok");
+    }
+}

--- a/src/test/java/com/mercadotech/authserver/adapter/mapper/TokenResponseMapperTest.java
+++ b/src/test/java/com/mercadotech/authserver/adapter/mapper/TokenResponseMapperTest.java
@@ -1,0 +1,19 @@
+package com.mercadotech.authserver.adapter.mapper;
+
+import com.mercadotech.authserver.adapter.dto.TokenResponse;
+import com.mercadotech.authserver.domain.model.TokenData;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenResponseMapperTest {
+
+    @Test
+    void fromTokenDataMapsToken() {
+        TokenData data = TokenData.builder().token("tok").build();
+
+        TokenResponse response = TokenResponseMapper.from(data);
+
+        assertThat(response.getToken()).isEqualTo("tok");
+    }
+}

--- a/src/test/java/com/mercadotech/authserver/application/mapper/TokenDataMapperTest.java
+++ b/src/test/java/com/mercadotech/authserver/application/mapper/TokenDataMapperTest.java
@@ -1,0 +1,16 @@
+package com.mercadotech.authserver.application.mapper;
+
+import com.mercadotech.authserver.domain.model.TokenData;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenDataMapperTest {
+
+    @Test
+    void fromMapsToken() {
+        TokenData data = TokenDataMapper.from("tok");
+
+        assertThat(data.getToken()).isEqualTo("tok");
+    }
+}

--- a/src/test/java/com/mercadotech/authserver/domain/mapper/CredentialsMapperTest.java
+++ b/src/test/java/com/mercadotech/authserver/domain/mapper/CredentialsMapperTest.java
@@ -1,0 +1,17 @@
+package com.mercadotech.authserver.domain.mapper;
+
+import com.mercadotech.authserver.domain.model.Credentials;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CredentialsMapperTest {
+
+    @Test
+    void fromMapsValues() {
+        Credentials credentials = CredentialsMapper.from("id", "secret");
+
+        assertThat(credentials.getClientId()).isEqualTo("id");
+        assertThat(credentials.getClientSecret()).isEqualTo("secret");
+    }
+}

--- a/src/test/java/com/mercadotech/authserver/domain/mapper/TokenDataMapperTest.java
+++ b/src/test/java/com/mercadotech/authserver/domain/mapper/TokenDataMapperTest.java
@@ -1,0 +1,16 @@
+package com.mercadotech.authserver.domain.mapper;
+
+import com.mercadotech.authserver.domain.model.TokenData;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenDataMapperTest {
+
+    @Test
+    void fromMapsToken() {
+        TokenData data = TokenDataMapper.from("tok");
+
+        assertThat(data.getToken()).isEqualTo("tok");
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for various mappers
- cover error branch in `AuthController`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685427fb3e7c8324bfbd19d97e770624