### PR TITLE
Add structured logger instance usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ The application logs messages in JSON format to make aggregation easier. Each en
 ```
 
 The pod name is taken from the `POD_NAME` environment variable and the correlation ID comes from the MDC key `correlation_id`.
-=======
+Classes that generate log entries should instantiate a `DefaultStructuredLogger`
+and delegate logging to its `info`, `warn` and `error` methods. These methods
+accept the log message and an optional correlation ID that is automatically
+stored in the MDC before the entry is written.
 Este projeto demonstra uma arquitetura hexagonal simples para um servidor de autenticação baseado em Spring Boot. Os serviços disponibilizados permitem gerar e validar tokens JWT utilizando um `clientId` e um `clientSecret`.
 
 ## Requisitos

--- a/src/main/java/com/mercadotech/authserver/logging/DefaultStructuredLogger.java
+++ b/src/main/java/com/mercadotech/authserver/logging/DefaultStructuredLogger.java
@@ -1,0 +1,46 @@
+package com.mercadotech.authserver.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+/**
+ * Default implementation of {@link StructuredLogger} that delegates to an SLF4J
+ * {@link Logger} instance.
+ */
+public class DefaultStructuredLogger implements StructuredLogger {
+
+    private final Logger logger;
+
+    public DefaultStructuredLogger(Class<?> clazz) {
+        this.logger = LoggerFactory.getLogger(clazz);
+    }
+
+    @Override
+    public void info(String message, String correlationId) {
+        logWithCorrelationId(() -> logger.info(message), correlationId);
+    }
+
+    @Override
+    public void warn(String message, String correlationId) {
+        logWithCorrelationId(() -> logger.warn(message), correlationId);
+    }
+
+    @Override
+    public void error(String message, String correlationId, Throwable t) {
+        logWithCorrelationId(() -> logger.error(message, t), correlationId);
+    }
+
+    private void logWithCorrelationId(Runnable action, String correlationId) {
+        if (correlationId != null) {
+            MDC.put("correlation_id", correlationId);
+        }
+        try {
+            action.run();
+        } finally {
+            if (correlationId != null) {
+                MDC.remove("correlation_id");
+            }
+        }
+    }
+}

--- a/src/main/java/com/mercadotech/authserver/logging/StructuredLogger.java
+++ b/src/main/java/com/mercadotech/authserver/logging/StructuredLogger.java
@@ -1,0 +1,32 @@
+package com.mercadotech.authserver.logging;
+
+/**
+ * Contract for writing structured log entries.
+ */
+public interface StructuredLogger {
+
+    /**
+     * Writes an INFO level entry.
+     *
+     * @param message       the message to log
+     * @param correlationId optional correlation identifier
+     */
+    void info(String message, String correlationId);
+
+    /**
+     * Writes a WARN level entry.
+     *
+     * @param message       the message to log
+     * @param correlationId optional correlation identifier
+     */
+    void warn(String message, String correlationId);
+
+    /**
+     * Writes an ERROR level entry.
+     *
+     * @param message       the message to log
+     * @param correlationId optional correlation identifier
+     * @param t             exception related to the error
+     */
+    void error(String message, String correlationId, Throwable t);
+}


### PR DESCRIPTION
## Summary
- revise StructuredLogger to be a plain interface
- add `DefaultStructuredLogger` implementation
- instantiate `DefaultStructuredLogger` inside `AuthController`
- update README to explain how to use the logger instance
- annotate `AuthController` with Lombok `@AllArgsConstructor`
- update tests for new constructor with metrics and logger

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685448ec067c83248a38a4c23e96b3c8