### PR TITLE
Implement correlation ID generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ The pod name is taken from the `POD_NAME` environment variable and the correlati
 Classes that generate log entries should instantiate a `DefaultStructuredLogger`
 and delegate logging to its `info`, `warn` and `error` methods. These methods
 accept the log message and an optional correlation ID that is automatically
-stored in the MDC before the entry is written.
+stored in the MDC before the entry is written. If the ID is not provided, the
+logger generates a random UUID.
 Este projeto demonstra uma arquitetura hexagonal simples para um servidor de autenticação baseado em Spring Boot. Os serviços disponibilizados permitem gerar e validar tokens JWT utilizando um `clientId` e um `clientSecret`.
 
 ## Requisitos

--- a/src/main/java/com/mercadotech/authserver/config/MetricsConfig.java
+++ b/src/main/java/com/mercadotech/authserver/config/MetricsConfig.java
@@ -1,0 +1,36 @@
+package com.mercadotech.authserver.config;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfig {
+
+    @Bean
+    public Counter tokensIssuedCounter(MeterRegistry registry) {
+        return Counter.builder("auth_tokens_issued")
+                .description("Number of tokens issued")
+                .register(registry);
+    }
+
+    @Bean
+    public Timer loginTimer(MeterRegistry registry) {
+        return Timer.builder("auth_login_latency")
+                .description("Latency of login endpoint")
+                .publishPercentileHistogram()
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(registry);
+    }
+
+    @Bean
+    public Timer validateTimer(MeterRegistry registry) {
+        return Timer.builder("auth_validate_latency")
+                .description("Latency of token validation endpoint")
+                .publishPercentileHistogram()
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(registry);
+    }
+}

--- a/src/main/java/com/mercadotech/authserver/logging/DefaultStructuredLogger.java
+++ b/src/main/java/com/mercadotech/authserver/logging/DefaultStructuredLogger.java
@@ -3,6 +3,7 @@ package com.mercadotech.authserver.logging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import java.util.UUID;
 
 /**
  * Default implementation of {@link StructuredLogger} that delegates to an SLF4J
@@ -31,16 +32,17 @@ public class DefaultStructuredLogger implements StructuredLogger {
         logWithCorrelationId(() -> logger.error(message, t), correlationId);
     }
 
+    /**
+     * Executes the logging action with the correlation ID stored in the MDC.
+     * A random UUID is generated when the provided ID is {@code null}.
+     */
     private void logWithCorrelationId(Runnable action, String correlationId) {
-        if (correlationId != null) {
-            MDC.put("correlation_id", correlationId);
-        }
+        String cid = correlationId != null ? correlationId : UUID.randomUUID().toString();
+        MDC.put("correlation_id", cid);
         try {
             action.run();
         } finally {
-            if (correlationId != null) {
-                MDC.remove("correlation_id");
-            }
+            MDC.remove("correlation_id");
         }
     }
 }


### PR DESCRIPTION
## Summary
- generate a UUID when DefaultStructuredLogger receives no correlation ID
- mention automatic generation of correlation IDs in README
- configure metrics beans for AuthController

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68544ebccea88324b436ef0175949650