### PR TITLE
Add Maven CI workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,20 @@
+name: Java CI
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Build and test with Maven
+        run: mvn -B verify

--- a/README.md
+++ b/README.md
@@ -131,3 +131,14 @@ O projeto expõe métricas via Spring Boot Actuator em `/actuator/prometheus` e 
 Os endpoints de login e validação possuem `Timer`s registrados no `MeterRegistry`,
 publicando histogramas e percentis (50%, 95% e 99%) de latência.
 
+
+## Integração Contínua
+
+Este repositório utiliza o GitHub Actions para compilar e executar os testes do projeto a cada push ou pull request. O fluxo de trabalho é definido em `.github/workflows/maven.yml` e executa o comando:
+
+```bash
+mvn -B verify
+```
+
+Isso garante que o build está sempre saudável antes de novas alterações serem mescladas.
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `mvn -B verify`
- document the new CI process in README

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854536ac5808324b57f06dbd4ebf5ff