### PR TITLE
Fix deprecated Jackson naming strategy

### DIFF
--- a/src/main/java/com/mercadotech/authserver/adapter/dto/LoginRequest.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/dto/LoginRequest.java
@@ -1,6 +1,6 @@
 package com.mercadotech.authserver.adapter.dto;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class LoginRequest {
     private String clientId;
     private String clientSecret;

--- a/src/main/java/com/mercadotech/authserver/adapter/dto/ValidateRequest.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/dto/ValidateRequest.java
@@ -1,6 +1,6 @@
 package com.mercadotech.authserver.adapter.dto;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ValidateRequest {
     private String token;
     private String clientSecret;


### PR DESCRIPTION
## Summary
- use newer `PropertyNamingStrategies` for DTOs

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685461027a908324878c9a93a030db07