### PR TITLE
Add error severity logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The application logs messages in JSON format to make aggregation easier. Each en
 {
   "timestamp": "2025-06-19T14:00:00Z",
   "level": "INFO",
+  "severity": "INFO",
   "class": "class-name",
   "pod_name": "order-service-abc123",
   "message": "Order processed successfully",

--- a/src/main/java/com/mercadotech/authserver/adapter/JwtTokenService.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/JwtTokenService.java
@@ -3,6 +3,8 @@ package com.mercadotech.authserver.adapter;
 import com.mercadotech.authserver.domain.TokenService;
 import com.mercadotech.authserver.domain.model.Credentials;
 import com.mercadotech.authserver.domain.model.TokenData;
+import com.mercadotech.authserver.logging.DefaultStructuredLogger;
+import com.mercadotech.authserver.logging.StructuredLogger;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -16,6 +18,7 @@ import java.util.Date;
 public class JwtTokenService implements TokenService {
 
     private static final long EXPIRATION_MILLIS = 3600000; // 1 hour
+    private final StructuredLogger logger = new DefaultStructuredLogger(JwtTokenService.class);
 
     @Override
     public TokenData generateToken(Credentials credentials) {
@@ -42,6 +45,7 @@ public class JwtTokenService implements TokenService {
                     .getBody();
             return claims.getExpiration().after(new Date());
         } catch (Exception e) {
+            logger.error("Token validation error", null, e);
             return false;
         }
     }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}", "application": "${HOSTNAME}","level":"%level","class":"%logger{36}","pod_name":"${POD_NAME}","message":"%msg","correlation_id":"%X{correlation_id}"}%n</pattern>
+            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}", "application": "${HOSTNAME}","level":"%level","severity":"%level","class":"%logger{36}","pod_name":"${POD_NAME}","message":"%msg","correlation_id":"%X{correlation_id}"}%n</pattern>
         </encoder>
     </appender>
     <root level="INFO">


### PR DESCRIPTION
## Summary
- add `severity` field to logback pattern and README example
- log token validation errors in `JwtTokenService`

## Testing
- `mvn -B verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685468fec7108324a2afccf37926c92b