### PR TITLE
Integrate execution context with structured logging

### DIFF
--- a/src/main/java/com/mercadotech/authserver/context/ExecutionContext.java
+++ b/src/main/java/com/mercadotech/authserver/context/ExecutionContext.java
@@ -1,0 +1,44 @@
+package com.mercadotech.authserver.context;
+
+/**
+ * Simple contract for storing and retrieving values during the execution of a
+ * single thread.
+ */
+public interface ExecutionContext {
+
+    /**
+     * Stores a value associated with the given key.
+     *
+     * @param key   identifier of the value
+     * @param value value to store
+     */
+    void put(String key, Object value);
+
+    /**
+     * Retrieves the value associated with the given key or {@code null} when
+     * none is present.
+     *
+     * @param key identifier of the value
+     * @return stored value or {@code null}
+     */
+    Object get(String key);
+
+    /**
+     * Removes a value associated with the given key.
+     *
+     * @param key identifier of the value
+     */
+    void remove(String key);
+
+    /**
+     * Clears all stored values from this context.
+     */
+    void clear();
+
+    /**
+     * Returns a copy of all stored values.
+     *
+     * @return map containing the current context values
+     */
+    java.util.Map<String, Object> values();
+}

--- a/src/main/java/com/mercadotech/authserver/context/ThreadLocalExecutionContext.java
+++ b/src/main/java/com/mercadotech/authserver/context/ThreadLocalExecutionContext.java
@@ -1,0 +1,38 @@
+package com.mercadotech.authserver.context;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@link ExecutionContext} implementation backed by a {@link ThreadLocal} map.
+ */
+public class ThreadLocalExecutionContext implements ExecutionContext {
+
+    private static final ThreadLocal<Map<String, Object>> CONTEXT =
+            ThreadLocal.withInitial(HashMap::new);
+
+    @Override
+    public void put(String key, Object value) {
+        CONTEXT.get().put(key, value);
+    }
+
+    @Override
+    public Object get(String key) {
+        return CONTEXT.get().get(key);
+    }
+
+    @Override
+    public void remove(String key) {
+        CONTEXT.get().remove(key);
+    }
+
+    @Override
+    public void clear() {
+        CONTEXT.get().clear();
+    }
+
+    @Override
+    public Map<String, Object> values() {
+        return new HashMap<>(CONTEXT.get());
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}", "application": "${HOSTNAME}","level":"%level","severity":"%level","class":"%logger{36}","pod_name":"${POD_NAME}","message":"%msg","correlation_id":"%X{correlation_id}"}%n</pattern>
+            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}", "application": "${HOSTNAME}","level":"%level","severity":"%level","class":"%logger{36}","pod_name":"${POD_NAME}","message":"%msg","correlation_id":"%X{correlation_id}","context":"%X{context}"}%n</pattern>
         </encoder>
     </appender>
     <root level="INFO">


### PR DESCRIPTION
## Summary
- attach `ExecutionContext` values to log entries
- expose context map through `ExecutionContext` API
- update `DefaultStructuredLogger` to write context to MDC
- include context field in the logback pattern
- use the new logger constructor in `AuthController` and demonstrate usage in README

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685470028fe48324b84d9ff4ebd33019