### PR TITLE
Add ThreadContext support to logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ The application logs messages in JSON format to make aggregation easier. Each en
 }
 ```
 
-The pod name is taken from the `POD_NAME` environment variable and the correlation ID comes from the MDC key `correlation_id`.
-Classes that generate log entries should instantiate a `DefaultStructuredLogger`
-and delegate logging to its `info`, `warn` and `error` methods. These methods
-accept the log message and an optional correlation ID that is automatically
-stored in the MDC before the entry is written. If the ID is not provided, the
-logger generates a random UUID.
+The pod name is taken from the `POD_NAME` environment variable. The correlation
+ID is kept in a thread-local context under the key `correlation_id` and added to
+the MDC when a message is logged. Classes that generate log entries should
+instantiate a `DefaultStructuredLogger` and delegate logging to its `info`,
+`warn` and `error` methods. These methods accept the log message and an optional
+correlation ID. If none is provided, the logger reuses the one stored in the
+context or generates a random UUID, storing it for subsequent entries.
 Este projeto demonstra uma arquitetura hexagonal simples para um servidor de autenticação baseado em Spring Boot. Os serviços disponibilizados permitem gerar e validar tokens JWT utilizando um `clientId` e um `clientSecret`.
 
 ## Requisitos

--- a/src/main/java/com/mercadotech/authserver/context/ThreadContext.java
+++ b/src/main/java/com/mercadotech/authserver/context/ThreadContext.java
@@ -1,0 +1,58 @@
+package com.mercadotech.authserver.context;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Stores variables scoped to the current thread using {@link ThreadLocal}.
+ */
+public final class ThreadContext {
+
+    private static final ThreadLocal<Map<String, Object>> CONTEXT =
+            ThreadLocal.withInitial(HashMap::new);
+
+    private ThreadContext() {
+    }
+
+    /**
+     * Stores a value in the context for the current thread.
+     *
+     * @param key   key under which the value will be stored
+     * @param value value to store
+     */
+    public static void put(String key, Object value) {
+        CONTEXT.get().put(key, value);
+    }
+
+    /**
+     * Retrieves a value from the context, casting it to the requested type.
+     * Returns {@code null} when the key is not present.
+     *
+     * @param key  key of the value
+     * @param type expected class of the value
+     * @param <T>  type parameter
+     * @return stored value or {@code null}
+     * @throws ClassCastException when the stored value is not of the requested type
+     */
+    public static <T> T get(String key, Class<T> type) {
+        Object value = CONTEXT.get().get(key);
+        if (value == null) {
+            return null;
+        }
+        return type.cast(value);
+    }
+
+    /**
+     * Removes the value associated with the given key for the current thread.
+     */
+    public static void remove(String key) {
+        CONTEXT.get().remove(key);
+    }
+
+    /**
+     * Clears all values for the current thread.
+     */
+    public static void clear() {
+        CONTEXT.remove();
+    }
+}

--- a/src/test/java/com/mercadotech/authserver/context/ThreadContextTest.java
+++ b/src/test/java/com/mercadotech/authserver/context/ThreadContextTest.java
@@ -1,0 +1,35 @@
+package com.mercadotech.authserver.context;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThreadContextTest {
+
+    @AfterEach
+    void tearDown() {
+        ThreadContext.clear();
+    }
+
+    @Test
+    void storesAndRetrievesValueInSameThread() {
+        ThreadContext.put("foo", "bar");
+
+        String value = ThreadContext.get("foo", String.class);
+
+        assertThat(value).isEqualTo("bar");
+    }
+
+    @Test
+    void valuesAreThreadLocal() throws Exception {
+        ThreadContext.put("foo", "bar");
+        final String[] fromOtherThread = new String[1];
+        Thread t = new Thread(() -> fromOtherThread[0] = ThreadContext.get("foo", String.class));
+        t.start();
+        t.join();
+
+        assertThat(fromOtherThread[0]).isNull();
+        assertThat(ThreadContext.get("foo", String.class)).isEqualTo("bar");
+    }
+}

--- a/src/test/java/com/mercadotech/authserver/logging/DefaultStructuredLoggerTest.java
+++ b/src/test/java/com/mercadotech/authserver/logging/DefaultStructuredLoggerTest.java
@@ -1,0 +1,44 @@
+package com.mercadotech.authserver.logging;
+
+import com.mercadotech.authserver.context.ThreadContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultStructuredLoggerTest {
+
+    private final StructuredLogger logger = new DefaultStructuredLogger(DefaultStructuredLoggerTest.class);
+
+    @AfterEach
+    void clearContext() {
+        ThreadContext.clear();
+    }
+
+    @Test
+    void storesCorrelationIdInThreadContext() {
+        logger.info("msg", "cid");
+
+        String value = ThreadContext.get("correlation_id", String.class);
+
+        assertThat(value).isEqualTo("cid");
+    }
+
+    @Test
+    void usesIdFromThreadContextWhenNullProvided() {
+        ThreadContext.put("correlation_id", "foo");
+
+        logger.warn("msg", null);
+
+        assertThat(ThreadContext.get("correlation_id", String.class)).isEqualTo("foo");
+    }
+
+    @Test
+    void generatesIdWhenNoneProvided() {
+        logger.error("msg", null, null);
+
+        String value = ThreadContext.get("correlation_id", String.class);
+
+        assertThat(value).isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary
- integrate `ThreadContext` with `DefaultStructuredLogger`
- document thread context behavior in README
- test logger and context interaction

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685475a69ef883248717b84c6406110b