### PR TITLE
Save client credentials to PostgreSQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,15 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
             <version>0.11.5</version>

--- a/src/main/java/com/mercadotech/authserver/adapter/database/entity/CredentialsEntity.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/database/entity/CredentialsEntity.java
@@ -1,0 +1,21 @@
+package com.mercadotech.authserver.adapter.database.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "credentials")
+public class CredentialsEntity {
+    @Id
+    private String clientId;
+    private String clientSecret;
+}

--- a/src/main/java/com/mercadotech/authserver/adapter/database/repository/CredentialsRepository.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/database/repository/CredentialsRepository.java
@@ -1,0 +1,9 @@
+package com.mercadotech.authserver.adapter.database.repository;
+
+import com.mercadotech.authserver.adapter.database.entity.CredentialsEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CredentialsRepository extends JpaRepository<CredentialsEntity, String> {
+}

--- a/src/main/java/com/mercadotech/authserver/adapter/server/controller/AuthController.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/server/controller/AuthController.java
@@ -8,6 +8,8 @@ import com.mercadotech.authserver.adapter.server.mapper.CredentialsMapper;
 import com.mercadotech.authserver.adapter.server.mapper.TokenMapper;
 import com.mercadotech.authserver.adapter.server.mapper.TokenResponseMapper;
 import com.mercadotech.authserver.application.useCase.TokenUseCase;
+import com.mercadotech.authserver.adapter.database.entity.CredentialsEntity;
+import com.mercadotech.authserver.adapter.database.repository.CredentialsRepository;
 import com.mercadotech.authserver.domain.model.Credentials;
 import com.mercadotech.authserver.domain.model.TokenData;
 import java.util.UUID;
@@ -33,6 +35,7 @@ public class AuthController {
     private final Counter tokensIssuedCounter;
     private final Timer loginTimer;
     private final Timer validateTimer;
+    private final CredentialsRepository credentialsRepository;
     private final StructuredLogger logger = new DefaultStructuredLogger(AuthController.class);
 
     @PostMapping("/login")
@@ -42,6 +45,10 @@ public class AuthController {
             validateUuid(request.getClientSecret());
             return loginTimer.record(() -> {
                 Credentials credentials = CredentialsMapper.from(request);
+                credentialsRepository.save(CredentialsEntity.builder()
+                        .clientId(credentials.getClientId())
+                        .clientSecret(credentials.getClientSecret())
+                        .build());
                 TokenData tokenData = tokenUseCase.generateToken(credentials);
                 tokensIssuedCounter.increment();
                 logger.info(String.format("Login success for client %s", credentials.getClientId()), null);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,3 +15,12 @@ management:
             requests: 0.5,0.95,0.99
 LOG_PATTERN: "%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n"
 POD_NAME: "mercadotech-auth-server"
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/authdb
+    username: postgres
+    password: postgres
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/src/test/java/com/mercadotech/authserver/adapter/AuthControllerTest.java
+++ b/src/test/java/com/mercadotech/authserver/adapter/AuthControllerTest.java
@@ -5,6 +5,7 @@ import com.mercadotech.authserver.adapter.server.dto.TokenResponse;
 import com.mercadotech.authserver.adapter.server.dto.ValidateRequest;
 import com.mercadotech.authserver.adapter.server.dto.ValidateResponse;
 import com.mercadotech.authserver.adapter.server.controller.AuthController;
+import com.mercadotech.authserver.adapter.database.repository.CredentialsRepository;
 import com.mercadotech.authserver.logging.StructuredLogger;
 import com.mercadotech.authserver.logging.DefaultStructuredLogger;
 import io.micrometer.core.instrument.Counter;
@@ -30,6 +31,7 @@ class AuthControllerTest {
     private Counter counter;
     private Timer loginTimer;
     private Timer validateTimer;
+    private CredentialsRepository repository;
     private StructuredLogger logger;
 
     @BeforeEach
@@ -49,8 +51,9 @@ class AuthControllerTest {
                 .publishPercentileHistogram()
                 .publishPercentiles(0.5, 0.95, 0.99)
                 .register(registry);
+        repository = Mockito.mock(CredentialsRepository.class);
         logger = new DefaultStructuredLogger(AuthController.class);
-        controller = new AuthController(useCase, counter, loginTimer, validateTimer);
+        controller = new AuthController(useCase, counter, loginTimer, validateTimer, repository);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add JPA and PostgreSQL dependencies
- store client credentials via CredentialsEntity and repository
- persist credentials on login
- configure datasource properties
- adjust AuthController tests for new dependency

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547ab244508324b3aed017c8183b72