### PR TITLE
Implement credentials persistence service

### DIFF
--- a/src/main/java/com/mercadotech/authserver/adapter/server/controller/AuthController.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/server/controller/AuthController.java
@@ -8,8 +8,7 @@ import com.mercadotech.authserver.adapter.server.mapper.CredentialsMapper;
 import com.mercadotech.authserver.adapter.server.mapper.TokenMapper;
 import com.mercadotech.authserver.adapter.server.mapper.TokenResponseMapper;
 import com.mercadotech.authserver.application.useCase.TokenUseCase;
-import com.mercadotech.authserver.adapter.database.entity.CredentialsEntity;
-import com.mercadotech.authserver.adapter.database.repository.CredentialsRepository;
+import com.mercadotech.authserver.application.service.CredentialsService;
 import com.mercadotech.authserver.domain.model.Credentials;
 import com.mercadotech.authserver.domain.model.TokenData;
 import java.util.UUID;
@@ -35,7 +34,7 @@ public class AuthController {
     private final Counter tokensIssuedCounter;
     private final Timer loginTimer;
     private final Timer validateTimer;
-    private final CredentialsRepository credentialsRepository;
+    private final CredentialsService credentialsService;
     private final StructuredLogger logger = new DefaultStructuredLogger(AuthController.class);
 
     @PostMapping("/login")
@@ -45,10 +44,7 @@ public class AuthController {
             validateUuid(request.getClientSecret());
             return loginTimer.record(() -> {
                 Credentials credentials = CredentialsMapper.from(request);
-                credentialsRepository.save(CredentialsEntity.builder()
-                        .clientId(credentials.getClientId())
-                        .clientSecret(credentials.getClientSecret())
-                        .build());
+                credentialsService.save(credentials);
                 TokenData tokenData = tokenUseCase.generateToken(credentials);
                 tokensIssuedCounter.increment();
                 logger.info(String.format("Login success for client %s", credentials.getClientId()), null);

--- a/src/main/java/com/mercadotech/authserver/application/service/CredentialsService.java
+++ b/src/main/java/com/mercadotech/authserver/application/service/CredentialsService.java
@@ -1,0 +1,7 @@
+package com.mercadotech.authserver.application.service;
+
+import com.mercadotech.authserver.domain.model.Credentials;
+
+public interface CredentialsService {
+    void save(Credentials credentials);
+}

--- a/src/main/java/com/mercadotech/authserver/application/service/CredentialsServiceImpl.java
+++ b/src/main/java/com/mercadotech/authserver/application/service/CredentialsServiceImpl.java
@@ -1,0 +1,23 @@
+package com.mercadotech.authserver.application.service;
+
+import com.mercadotech.authserver.adapter.database.entity.CredentialsEntity;
+import com.mercadotech.authserver.adapter.database.repository.CredentialsRepository;
+import com.mercadotech.authserver.domain.model.Credentials;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CredentialsServiceImpl implements CredentialsService {
+
+    private final CredentialsRepository repository;
+
+    @Override
+    public void save(Credentials credentials) {
+        CredentialsEntity entity = CredentialsEntity.builder()
+                .clientId(credentials.getClientId())
+                .clientSecret(credentials.getClientSecret())
+                .build();
+        repository.save(entity);
+    }
+}

--- a/src/test/java/com/mercadotech/authserver/adapter/AuthControllerTest.java
+++ b/src/test/java/com/mercadotech/authserver/adapter/AuthControllerTest.java
@@ -5,7 +5,7 @@ import com.mercadotech.authserver.adapter.server.dto.TokenResponse;
 import com.mercadotech.authserver.adapter.server.dto.ValidateRequest;
 import com.mercadotech.authserver.adapter.server.dto.ValidateResponse;
 import com.mercadotech.authserver.adapter.server.controller.AuthController;
-import com.mercadotech.authserver.adapter.database.repository.CredentialsRepository;
+import com.mercadotech.authserver.application.service.CredentialsService;
 import com.mercadotech.authserver.logging.StructuredLogger;
 import com.mercadotech.authserver.logging.DefaultStructuredLogger;
 import io.micrometer.core.instrument.Counter;
@@ -31,7 +31,7 @@ class AuthControllerTest {
     private Counter counter;
     private Timer loginTimer;
     private Timer validateTimer;
-    private CredentialsRepository repository;
+    private CredentialsService credentialsService;
     private StructuredLogger logger;
 
     @BeforeEach
@@ -51,9 +51,9 @@ class AuthControllerTest {
                 .publishPercentileHistogram()
                 .publishPercentiles(0.5, 0.95, 0.99)
                 .register(registry);
-        repository = Mockito.mock(CredentialsRepository.class);
+        credentialsService = Mockito.mock(CredentialsService.class);
         logger = new DefaultStructuredLogger(AuthController.class);
-        controller = new AuthController(useCase, counter, loginTimer, validateTimer, repository);
+        controller = new AuthController(useCase, counter, loginTimer, validateTimer, credentialsService);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add `CredentialsService` interface and implementation to persist credentials
- refactor `AuthController` to depend on the new service
- update controller unit test for constructor change

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547d71bb6c8324a2edc2029f87d747