### PR TITLE
Add helper script for Postgres via Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ docker build -t auth-server .
 docker run -p 8080:8080 auth-server
 ```
 
+### Banco de dados PostgreSQL com Docker
+
+Para iniciar rapidamente um banco PostgreSQL local execute o script abaixo:
+
+```bash
+./scripts/start-postgres.sh
+```
+
+O script irá criar um container nomeado `auth-postgres` escutando na porta `5432` com as credenciais definidas em `src/main/resources/application.yaml`.
+
 ## Endpoints principais
 
 ### `POST /login`

--- a/scripts/start-postgres.sh
+++ b/scripts/start-postgres.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+CONTAINER_NAME="auth-postgres"
+IMAGE="postgres:15"
+
+if [ "$(docker ps -a -q -f name=${CONTAINER_NAME})" ]; then
+  echo "Container ${CONTAINER_NAME} already exists"
+  exit 0
+fi
+
+docker run -d \
+  --name ${CONTAINER_NAME} \
+  -e POSTGRES_DB=authdb \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -p 5432:5432 \
+  ${IMAGE}


### PR DESCRIPTION
## Summary
- add script to spin up a Postgres container
- document the script in README

## Testing
- `mvn -B verify` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68547f3409fc832486cd3dea4897a35e