### PR TITLE
Add credentials table SQL script

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Para iniciar rapidamente um banco PostgreSQL local execute o script abaixo:
 ```
 
 O script irá criar um container nomeado `auth-postgres` escutando na porta `5432` com as credenciais definidas em `src/main/resources/application.yaml`.
+Com o container em execução, crie a tabela de credenciais executando:
+
+```bash
+psql -h localhost -U postgres -d authdb -f scripts/create_credentials_table.sql
+```
 
 ## Endpoints principais
 

--- a/scripts/create_credentials_table.sql
+++ b/scripts/create_credentials_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS credentials (
+    client_id VARCHAR(255) PRIMARY KEY,
+    client_secret VARCHAR(255) NOT NULL
+);


### PR DESCRIPTION
## Summary
- add `create_credentials_table.sql` to bootstrap DB
- document how to execute the script in README

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854862d6ccc8324b2db9a69971765a7