### PR TITLE
Translate log messages to Portuguese

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,26 +9,20 @@ are used to reduce boilerplate in service implementations.
 
 ## Logging
 
-The application logs messages in JSON format to make aggregation easier. Each entry contains the timestamp, log level, class name, Kubernetes pod name and a correlation ID if available:
+A aplicação registra mensagens em formato JSON para facilitar a agregação. Cada entrada inclui data e hora, nível do log, nome da classe, nome do pod do Kubernetes e um ID de correlação, se disponível:
 
 ```json
 {
   "timestamp": "2025-06-19T14:00:00Z",
   "level": "INFO",
-  "class": "class-name",
+  "class": "nome-da-classe",
   "pod_name": "order-service-abc123",
-  "message": "Order processed successfully",
+  "message": "Pedido processado com sucesso",
   "correlation_id": "uuid"
 }
 ```
 
-The pod name is taken from the `POD_NAME` environment variable. The correlation
-ID is kept in a thread-local context under the key `correlation_id` and added to
-the MDC when a message is logged. Classes that generate log entries should
-instantiate a `DefaultStructuredLogger` and delegate logging to its `info`,
-`warn` and `error` methods. These methods accept the log message and an optional
-correlation ID. If none is provided, the logger reuses the one stored in the
-context or generates a random UUID, storing it for subsequent entries.
+O nome do pod é obtido a partir da variável de ambiente `POD_NAME`. O ID de correlação é mantido em um contexto de thread sob a chave `correlation_id` e adicionado ao MDC quando uma mensagem é registrada. As classes que geram logs devem instanciar um `DefaultStructuredLogger` e delegar a ele as chamadas `info`, `warn` e `error`. Esses métodos recebem a mensagem e um ID de correlação opcional. Caso nenhum seja fornecido, o logger reutiliza o ID armazenado no contexto ou gera um UUID aleatório para as próximas entradas.
 Este projeto demonstra uma arquitetura hexagonal simples para um servidor de autenticação baseado em Spring Boot. Os serviços disponibilizados permitem gerar e validar tokens JWT utilizando um `clientId` e um `clientSecret`.
 
 ## Requisitos

--- a/src/main/java/com/mercadotech/authserver/adapter/server/controller/AuthController.java
+++ b/src/main/java/com/mercadotech/authserver/adapter/server/controller/AuthController.java
@@ -47,12 +47,12 @@ public class AuthController {
                 credentialsService.save(credentials);
                 TokenData tokenData = tokenUseCase.generateToken(credentials);
                 tokensIssuedCounter.increment();
-                logger.info(String.format("Login success for client %s", credentials.getClientId()), null);
+                logger.info(String.format("Login realizado com sucesso para o cliente %s", credentials.getClientId()), null);
                 TokenResponse response = TokenResponseMapper.from(tokenData);
                 return ResponseEntity.ok(response);
             });
         } catch (Exception e) {
-            logger.error(String.format("Login failed for client %s", request.getClientId()), null, e);
+            logger.error(String.format("Falha no login para o cliente %s", request.getClientId()), null, e);
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
     }
@@ -63,7 +63,7 @@ public class AuthController {
             try {
                 validateUuid(request.getClientSecret());
             } catch (Exception e) {
-                logger.error("Invalid clientSecret format", null, e);
+                logger.error("Formato do clientSecret inválido", null, e);
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                         .body(ValidateResponse.builder().valid(false).build());
             }
@@ -71,10 +71,10 @@ public class AuthController {
             TokenData tokenData = TokenMapper.from(request);
             boolean valid = tokenUseCase.validateToken(tokenData, credentials);
             if (valid) {
-                logger.info("Token validation success", null);
+                logger.info("Validação do token bem-sucedida", null);
                 return ResponseEntity.ok(ValidateResponse.builder().valid(true).build());
             } else {
-                logger.warn("Token validation failed", null);
+                logger.warn("Falha na validação do token", null);
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                         .body(ValidateResponse.builder().valid(false).build());
             }

--- a/src/main/java/com/mercadotech/authserver/application/service/JwtTokenService.java
+++ b/src/main/java/com/mercadotech/authserver/application/service/JwtTokenService.java
@@ -44,7 +44,7 @@ public class JwtTokenService implements TokenService {
                     .getBody();
             return claims.getExpiration().after(new Date());
         } catch (Exception e) {
-            logger.error("Failed to validate token", null, e);
+            logger.error("Erro ao validar o token", null, e);
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- translate log messages in controller and token service to Portuguese
- document logging section of README in Portuguese

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554d83634c83249a494584c0dbdcdf