### PR TITLE
Add Redis token cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/com/mercadotech/authserver/application/service/RedisTokenCacheService.java
+++ b/src/main/java/com/mercadotech/authserver/application/service/RedisTokenCacheService.java
@@ -1,0 +1,24 @@
+package com.mercadotech.authserver.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import com.mercadotech.authserver.logging.DefaultStructuredLogger;
+import com.mercadotech.authserver.logging.StructuredLogger;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisTokenCacheService implements TokenCacheService {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final Duration TTL = Duration.ofHours(1);
+    private final StructuredLogger logger = new DefaultStructuredLogger(RedisTokenCacheService.class);
+
+    @Override
+    public void save(String clientId, String token) {
+        redisTemplate.opsForValue().set(clientId, token, TTL);
+        logger.info(String.format("Cached token for client %s", clientId), null);
+    }
+}

--- a/src/main/java/com/mercadotech/authserver/application/service/TokenCacheService.java
+++ b/src/main/java/com/mercadotech/authserver/application/service/TokenCacheService.java
@@ -1,0 +1,5 @@
+package com.mercadotech.authserver.application.service;
+
+public interface TokenCacheService {
+    void save(String clientId, String token);
+}

--- a/src/main/java/com/mercadotech/authserver/application/useCase/TokenUseCaseImpl.java
+++ b/src/main/java/com/mercadotech/authserver/application/useCase/TokenUseCaseImpl.java
@@ -1,6 +1,9 @@
 package com.mercadotech.authserver.application.useCase;
 
 import com.mercadotech.authserver.application.service.TokenService;
+import com.mercadotech.authserver.application.service.TokenCacheService;
+import com.mercadotech.authserver.logging.DefaultStructuredLogger;
+import com.mercadotech.authserver.logging.StructuredLogger;
 import com.mercadotech.authserver.domain.model.Credentials;
 import com.mercadotech.authserver.domain.model.TokenData;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +14,15 @@ import org.springframework.stereotype.Service;
 public class TokenUseCaseImpl implements TokenUseCase {
 
     private final TokenService tokenService;
+    private final TokenCacheService tokenCacheService;
+    private final StructuredLogger logger = new DefaultStructuredLogger(TokenUseCaseImpl.class);
 
     @Override
     public TokenData generateToken(Credentials credentials) {
-        return tokenService.generateToken(credentials);
+        TokenData tokenData = tokenService.generateToken(credentials);
+        tokenCacheService.save(credentials.getClientId(), tokenData.getToken());
+        logger.info(String.format("Token generated for client %s", credentials.getClientId()), null);
+        return tokenData;
     }
 
     @Override

--- a/src/test/java/com/mercadotech/authserver/application/service/TokenUseCaseImplTest.java
+++ b/src/test/java/com/mercadotech/authserver/application/service/TokenUseCaseImplTest.java
@@ -14,12 +14,14 @@ import static org.mockito.Mockito.*;
 class TokenUseCaseImplTest {
 
     private TokenService tokenService;
+    private TokenCacheService cacheService;
     private TokenUseCase useCase;
 
     @BeforeEach
     void setUp() {
         tokenService = Mockito.mock(TokenService.class);
-        useCase = new TokenUseCaseImpl(tokenService);
+        cacheService = Mockito.mock(TokenCacheService.class);
+        useCase = new TokenUseCaseImpl(tokenService, cacheService);
     }
 
     @Test
@@ -36,6 +38,7 @@ class TokenUseCaseImplTest {
 
         assertThat(result).isEqualTo(tokenData);
         verify(tokenService).generateToken(credentials);
+        verify(cacheService).save("id", "token");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add structured log messages when tokens are generated and cached

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ee4696cc8324b2d8aba1ac8b9370