### PR TITLE
Add Redis startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ Com o container em execução, crie a tabela de credenciais executando:
 psql -h localhost -U postgres -d authdb -f scripts/create_credentials_table.sql
 ```
 
+### Redis com Docker
+
+Para armazenar o token do client secret em cache, execute:
+
+```bash
+./scripts/start-redis.sh
+```
+
+O script irá criar um container `auth-redis` ouvindo na porta `6379`.
+
 ## Endpoints principais
 
 ### `POST /login`

--- a/scripts/start-redis.sh
+++ b/scripts/start-redis.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+CONTAINER_NAME="auth-redis"
+IMAGE="redis:7"
+
+if [ "$(docker ps -a -q -f name=${CONTAINER_NAME})" ]; then
+  echo "Container ${CONTAINER_NAME} already exists"
+  exit 0
+fi
+
+docker run -d \
+  --name ${CONTAINER_NAME} \
+  -p 6379:6379 \
+  ${IMAGE}


### PR DESCRIPTION
## Summary
- add script to start a Redis container
- document Redis startup script in README

## Testing
- `mvn -B verify` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f38d218c8324854590781eb4c83e