### PR TITLE
Add Prometheus/Grafana monitoring setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Opcionalmente você pode utilizar o Dockerfile incluso:
 
 ```bash
 docker build -t auth-server .
-docker run -p 8080:8080 auth-server
+docker run -d --name auth-server \
+  --network auth-network \
+  -p 8080:8080 auth-server
 ```
 
 ### Banco de dados PostgreSQL com Docker
@@ -156,6 +158,21 @@ para consultar e testar os endpoints disponíveis.
 O projeto expõe métricas via Spring Boot Actuator em `/actuator/prometheus` e `/actuator/metrics`, permitindo integração com o Prometheus.
 Os endpoints de login e validação possuem `Timer`s registrados no `MeterRegistry`,
 publicando histogramas e percentis (50%, 95% e 99%) de latência.
+
+### Monitoramento com Prometheus e Grafana
+
+Com a aplicação em execução em um container `auth-server`, é possível iniciar
+Prometheus e Grafana executando:
+
+```bash
+./scripts/start-monitoring.sh
+```
+
+O script cria uma rede Docker `auth-network`, constrói uma imagem personalizada
+do Prometheus com uma configuração que coleta métricas do `auth-server` e
+inicia também o Grafana. Após a execução, acesse `http://localhost:3000` com as
+credenciais padrão `admin`/`admin` e adicione o Prometheus disponível em
+`http://auth-prometheus:9090` como fonte de dados para visualizar os gráficos.
 
 
 ## Integração Contínua

--- a/monitoring/prometheus/Dockerfile
+++ b/monitoring/prometheus/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus
+COPY prometheus.yml /etc/prometheus/

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'auth-server'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['auth-server:8080']

--- a/scripts/start-monitoring.sh
+++ b/scripts/start-monitoring.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+PROM_CONTAINER="auth-prometheus"
+GRAFANA_CONTAINER="auth-grafana"
+NETWORK="auth-network"
+PROM_IMAGE="custom-prometheus"
+GRAFANA_IMAGE="grafana/grafana-oss:10.4.2"
+
+# create network if it does not exist
+if ! docker network ls --format '{{.Name}}' | grep -q "^${NETWORK}$"; then
+  docker network create ${NETWORK}
+fi
+
+# build prometheus image
+docker build -t ${PROM_IMAGE} monitoring/prometheus
+
+# start prometheus container if not running
+if [ -z "$(docker ps -q -f name=${PROM_CONTAINER})" ]; then
+  if [ "$(docker ps -a -q -f name=${PROM_CONTAINER})" ]; then
+    docker rm ${PROM_CONTAINER}
+  fi
+  docker run -d --name ${PROM_CONTAINER} \
+    --network ${NETWORK} \
+    -p 9090:9090 \
+    ${PROM_IMAGE}
+fi
+
+# start grafana container if not running
+if [ -z "$(docker ps -q -f name=${GRAFANA_CONTAINER})" ]; then
+  if [ "$(docker ps -a -q -f name=${GRAFANA_CONTAINER})" ]; then
+    docker rm ${GRAFANA_CONTAINER}
+  fi
+  docker run -d --name ${GRAFANA_CONTAINER} \
+    --network ${NETWORK} \
+    -p 3000:3000 \
+    ${GRAFANA_IMAGE}
+fi
+
+cat <<MSG
+Prometheus running at http://localhost:9090
+Grafana running at http://localhost:3000 (default credentials admin/admin)
+MSG


### PR DESCRIPTION
## Summary
- add Prometheus Dockerfile and configuration
- add script to run Prometheus and Grafana containers
- update Docker instructions in README
- document monitoring setup in README

## Testing
- `mvn -B verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f7239ef483248d1b74925032906d